### PR TITLE
Update to CEF 96.0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ CEF4Delphi is an open source project created by Salvador Díaz Fau to embed Chro
 
 CEF4Delphi is based on DCEF3 and fpCEF3. The original license of those projects still applies to CEF4Delphi. Read the license terms in the first lines of any *.pas file.
 
-CEF4Delphi uses CEF 96.0.16 which includes Chromium 96.0.4664.55. 
+CEF4Delphi uses CEF 96.0.17 which includes Chromium 96.0.4664.93. 
 
 The CEF binaries used by CEF4Delphi are available for download at Spotify :
-* [Windows 32 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_windows32.tar.bz2)
-* [Windows 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_windows64.tar.bz2)
-* [Linux x86 32 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_linux32.tar.bz2)
-* [Linux x86 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_linux64.tar.bz2)
-* [Linux ARM 32 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_linuxarm.tar.bz2)
-* [Linux ARM 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_linuxarm64.tar.bz2)
-* [MacOS x86 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.16%2Bg89c902b%2Bchromium-96.0.4664.55_macosx64.tar.bz2)
+* [Windows 32 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_windows32.tar.bz2)
+* [Windows 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_windows64.tar.bz2)
+* [Linux x86 32 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_linux32.tar.bz2)
+* [Linux x86 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_linux64.tar.bz2)
+* [Linux ARM 32 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_linuxarm.tar.bz2)
+* [Linux ARM 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_linuxarm64.tar.bz2)
+* [MacOS x86 64 bits](https://cef-builds.spotifycdn.com/cef_binary_96.0.17%2Bg20e2617%2Bchromium-96.0.4664.93_macosx64.tar.bz2)
 
 CEF4Delphi was developed and tested on Delphi 11.0 and it has been tested in Delphi 7, Delphi XE, Delphi 10, Delphi 10.2, Delphi 10.3, Delphi 10.4 and Lazarus 2.2.0RC2/FPC 3.2.2. CEF4Delphi includes VCL, FireMonkey (FMX) and Lazarus components.
 
@@ -38,8 +38,7 @@ You can also support this project with Patreon.
 Additional:
 Delphinus-Support
 
-## Attribution
-Other projects :
+## Related projects
 * [WebView4Delphi](https://github.com/salvadordf/WebView4Delphi)
 * [DCEF3](https://github.com/hgourvest/dcef3) 
 * [fpCEF3](https://github.com/dliw/fpCEF3)

--- a/packages/cef4delphi_lazarus.lpk
+++ b/packages/cef4delphi_lazarus.lpk
@@ -21,7 +21,7 @@
     </CompilerOptions>
     <Description Value="CEF4Delphi is an open source project created by Salvador Díaz Fau to embed Chromium-based browsers in applications made with Delphi or Lazarus/FPC."/>
     <License Value="MPL 1.1"/>
-    <Version Major="96" Release="16"/>
+    <Version Major="96" Release="17"/>
     <Files Count="203">
       <Item1>
         <Filename Value="..\source\uCEFAccessibilityHandler.pas"/>

--- a/source/uCEFApplicationCore.pas
+++ b/source/uCEFApplicationCore.pas
@@ -66,13 +66,13 @@ uses
 const
   CEF_SUPPORTED_VERSION_MAJOR   = 96;
   CEF_SUPPORTED_VERSION_MINOR   = 0;
-  CEF_SUPPORTED_VERSION_RELEASE = 16;
+  CEF_SUPPORTED_VERSION_RELEASE = 17;
   CEF_SUPPORTED_VERSION_BUILD   = 0;
 
   CEF_CHROMEELF_VERSION_MAJOR   = 96;
   CEF_CHROMEELF_VERSION_MINOR   = 0;
   CEF_CHROMEELF_VERSION_RELEASE = 4664;
-  CEF_CHROMEELF_VERSION_BUILD   = 55;
+  CEF_CHROMEELF_VERSION_BUILD   = 93;
 
   {$IFDEF MSWINDOWS}
   LIBCEF_DLL     = 'libcef.dll';
@@ -493,7 +493,7 @@ type
       property HyperlinkAuditing                 : boolean                             read FHyperlinkAuditing                 write FHyperlinkAuditing;                // --no-pings
       property DisableNewBrowserInfoTimeout      : boolean                             read FDisableNewBrowserInfoTimeout      write FDisableNewBrowserInfoTimeout;     // --disable-new-browser-info-timeout
       property DevToolsProtocolLogFile           : ustring                             read FDevToolsProtocolLogFile           write FDevToolsProtocolLogFile;          // --devtools-protocol-log-file
-      property ForcedDeviceScaleFactor           : single                              read FForcedDeviceScaleFactor           write FForcedDeviceScaleFactor;          // --device-scale-factor
+      property ForcedDeviceScaleFactor           : single                              read FForcedDeviceScaleFactor           write FForcedDeviceScaleFactor;          // --force-device-scale-factor
       property DisableZygote                     : boolean                             read FDisableZygote                     write FDisableZygote;                    // --no-zygote
       property UseMockKeyChain                   : boolean                             read FUseMockKeyChain                   write FUseMockKeyChain;                  // --use-mock-keychain
       property DisableRequestHandlingForTesting  : boolean                             read FDisableRequestHandlingForTesting  write FDisableRequestHandlingForTesting; // --disable-request-handling-for-testing
@@ -787,7 +787,7 @@ begin
     // The main browser process will receive WM_QUERYENDSESSION before the subprocesses
     // and that allows to close the application in the right order.
     // See the MiniBrowser demo for all the details.
-    SetProcessShutdownParameters($100, SHUTDOWN_NORETRY);
+    SetProcessShutdownParameters(CHROMIUM_NONBROWSERSHUTDOWNPRIORITY - 1, SHUTDOWN_NORETRY);
   {$ENDIF}
 
   // Internal filelds

--- a/source/uCEFChromiumCore.pas
+++ b/source/uCEFChromiumCore.pas
@@ -769,7 +769,6 @@ type
       procedure   ClearDataForOrigin(const aOrigin : ustring; aStorageTypes : TCefClearDataStorageTypes = cdstAll);
       procedure   ClearCache;
 
-
       function    DeleteCookies(const url : ustring = ''; const cookieName : ustring = ''; aDeleteImmediately : boolean = False) : boolean;
       function    VisitAllCookies(aID : integer = 0) : boolean;
       function    VisitURLCookies(const url : ustring; includeHttpOnly : boolean = False; aID : integer = 0) : boolean;

--- a/source/uCEFConstants.pas
+++ b/source/uCEFConstants.pas
@@ -681,6 +681,11 @@ const
   USER_DEFAULT_SCREEN_DPI = 96;
   {$IFEND}
 
+  // This constant is defined by Chromium in chrome/app/main_dll_loader_win.cc
+  // It's used with SetProcessShutdownParameters to set a shutdown priority for the
+  // subprocesses. $280 is the default value for applications.
+  CHROMIUM_NONBROWSERSHUTDOWNPRIORITY = $280;
+
   {$IF NOT DECLARED(INFINITE)}
   INFINITE = Cardinal($FFFFFFFF);
   {$IFEND}

--- a/source/uCEFFMXBufferPanel.pas
+++ b/source/uCEFFMXBufferPanel.pas
@@ -48,7 +48,7 @@ uses
   System.SyncObjs,
   {$ENDIF}
   System.Classes, System.UIConsts, System.Types, System.UITypes,
-  {$IFDEF DELPHI17_UP}
+  {$IFDEF DELPHI19_UP}
   FMX.Graphics,
   {$ENDIF}
   FMX.Types, FMX.Controls, FMX.Forms,
@@ -123,7 +123,6 @@ type
       property HighSpeedDrawing : boolean            read FHighSpeedDrawing write FHighSpeedDrawing default True;
 
       {$IFDEF DELPHI17_UP}
-      property TabStop;
       property CanFocus;
       property CanParentFocus;
       property Height;
@@ -135,6 +134,9 @@ type
       property RotationAngle;
       property RotationCenter;
       property Scale;
+      {$ENDIF}
+      {$IFDEF DELPHI18_UP}
+      property TabStop;
       property Size;
       property OnResized;
       {$ENDIF}
@@ -162,7 +164,7 @@ implementation
 
 uses
   System.SysUtils, System.Math,
-  {$IFDEF MSWINDOWS}FMX.Helpers.Win,{$ENDIF}
+  {$IFDEF MSWINDOWS}{$IFDEF DELPHI24_UP}FMX.Helpers.Win,{$ENDIF}{$ENDIF}
   FMX.Platform, {$IFDEF MACOS}FMX.Platform.Mac,{$ENDIF}
   uCEFMiscFunctions, uCEFApplicationCore;
 
@@ -468,21 +470,27 @@ begin
 end;
 
 function TFMXBufferPanel.UpdateBufferDimensions(aWidth, aHeight : integer) : boolean;
+{$IFDEF DELPHI18_UP}
 var
   TempScale : single;
+{$ENDIF}
 begin
   Result    := False;
+  {$IFDEF DELPHI18_UP}
   TempScale := ScreenScale;
+  {$ENDIF}
 
   if ((FBuffer             =  nil)       or
+      {$IFDEF DELPHI18_UP}
       (FBuffer.BitmapScale <> TempScale) or
+      {$ENDIF}
       (FBuffer.Width       <> aWidth)    or
       (FBuffer.Height      <> aHeight))  then
     begin
       if (FBuffer <> nil) then FreeAndNil(FBuffer);
 
       FBuffer             := TBitmap.Create(aWidth, aHeight);
-      {$IFDEF DELPHI17_UP}
+      {$IFDEF DELPHI18_UP}
       FBuffer.BitmapScale := TempScale;
       FScanlineSize       := FBuffer.BytesPerLine;
       {$ELSE}
@@ -506,7 +514,9 @@ begin
       TempHeight := round(Height * TempScale);
 
       Result := (FBuffer <> nil) and
+                {$IFDEF DELPHI18_UP}
                 (FBuffer.BitmapScale = TempScale) and
+                {$ENDIF}
                 (FBuffer.Width       = TempWidth) and
                 (FBuffer.Height      = TempHeight);
 

--- a/source/uCEFFMXChromium.pas
+++ b/source/uCEFFMXChromium.pas
@@ -49,7 +49,10 @@ uses
   {$IFDEF MSWINDOWS}
   WinApi.Windows, WinApi.Messages, FMX.Platform.Win,
   {$ENDIF}
-  FMX.Types, FMX.Platform, FMX.Forms, FMX.Controls, FMX.Graphics,
+  FMX.Types, FMX.Platform, FMX.Forms, FMX.Controls,
+  {$IFDEF DELPHI19_UP}
+  FMX.Graphics,
+  {$ENDIF}
   uCEFTypes, uCEFInterfaces, uCEFChromiumCore;
 
 type
@@ -109,7 +112,7 @@ type
 implementation
 
 uses
-  {$IFDEF MSWINDOWS}FMX.Helpers.Win,{$ENDIF}
+  {$IFDEF MSWINDOWS}{$IFDEF DELPHI24_UP}FMX.Helpers.Win,{$ENDIF}{$ENDIF}
   System.SysUtils, System.Math,
   uCEFApplicationCore;
 
@@ -212,12 +215,12 @@ end;
 procedure TFMXChromium.MoveFormTo(const x, y: Integer);
 var
   TempForm : TCustomForm;
-  {$IFDEF DELPHI17_UP}
+  {$IFDEF DELPHI21_UP}
   TempRect : TRect;
   {$ENDIF}
 begin
   TempForm := GetParentForm;
-  {$IFDEF DELPHI17_UP}
+  {$IFDEF DELPHI21_UP}
   if (TempForm <> nil) then
     begin
       TempRect.Left   := min(max(x, max(round(screen.DesktopLeft), 0)), round(screen.DesktopWidth)  - TempForm.Width);
@@ -235,12 +238,12 @@ end;
 procedure TFMXChromium.MoveFormBy(const x, y: Integer);
 var
   TempForm : TCustomForm;
-  {$IFDEF DELPHI17_UP}
+  {$IFDEF DELPHI21_UP}
   TempRect : TRect;
   {$ENDIF}
 begin
   TempForm := GetParentForm;
-  {$IFDEF DELPHI17_UP}
+  {$IFDEF DELPHI21_UP}
   if (TempForm <> nil) then
     begin
       TempRect.Left   := min(max(TempForm.Left + x, max(round(screen.DesktopLeft), 0)), round(screen.DesktopWidth)  - TempForm.Width);
@@ -292,7 +295,7 @@ begin
   TempForm := GetParentForm;
 
   if (TempForm <> nil) then
-    {$IFDEF DELPHI17_UP}
+    {$IFDEF DELPHI21_UP}
     TempForm.Left := min(max(x, max(round(screen.DesktopLeft), 0)), round(screen.DesktopWidth) - TempForm.Width);
     {$ELSE}
     TempForm.Left := x;
@@ -306,7 +309,7 @@ begin
   TempForm := GetParentForm;
 
   if (TempForm <> nil) then
-    {$IFDEF DELPHI17_UP}
+    {$IFDEF DELPHI21_UP}
     TempForm.Top := min(max(y, max(round(screen.DesktopTop), 0)), round(screen.DesktopHeight) - TempForm.Height);
     {$ELSE}
     TempForm.Top := y;

--- a/source/uCEFFMXWindowParent.pas
+++ b/source/uCEFFMXWindowParent.pas
@@ -63,7 +63,7 @@ type
 
     public
       {$IFDEF MSWINDOWS}
-      procedure Reparent(const aNewParentHandle : TWindowHandle);
+      procedure Reparent(const aNewParentHandle : {$IFDEF DELPHI18_UP}TWindowHandle{$ELSE}TFmxHandle{$ENDIF});
       property  ChildWindowHandle : HWND   read GetChildWindowHandle;
       {$ENDIF}
 
@@ -130,11 +130,15 @@ begin
   end;
 end;
 
-procedure TFMXWindowParent.Reparent(const aNewParentHandle : TWindowHandle);
+procedure TFMXWindowParent.Reparent(const aNewParentHandle : {$IFDEF DELPHI18_UP}TWindowHandle{$ELSE}TFmxHandle{$ENDIF});
 var
   TempChildHandle, TempParentHandle : HWND;
 begin
+  {$IFDEF DELPHI18_UP}
   if (aNewParentHandle <> nil) then
+  {$ELSE}
+  if (aNewParentHandle <> 0) then
+  {$ENDIF}
     begin
       TempChildHandle  := FmxHandleToHWND(Handle);
       TempParentHandle := FmxHandleToHWND(aNewParentHandle);

--- a/source/uCEFFMXWorkScheduler.pas
+++ b/source/uCEFFMXWorkScheduler.pas
@@ -51,7 +51,6 @@ uses
 
 type
   {$IFNDEF FPC}{$IFDEF DELPHI16_UP}[ComponentPlatformsAttribute(pidWin32 or pidWin64)]{$ENDIF}{$ENDIF}
-
   TFMXWorkScheduler = class(TComponent)
     protected
       FThread             : TCEFWorkSchedulerThread;
@@ -276,10 +275,15 @@ begin
   if FUseQueueThread and (FQueueThread <> nil) and FQueueThread.Ready then
     FQueueThread.EnqueueValue(integer(delay_ms))
    else
-    TThread.ForceQueue(nil, procedure
-                            begin
-                              ScheduleWork(delay_ms);
-                            end);
+    {$IFDEF DELPHI18_UP}
+    TThread.ForceQueue(nil,
+    {$ELSE}
+    TThread.Queue(nil,
+    {$ENDIF}
+      procedure
+      begin
+        ScheduleWork(delay_ms);
+      end);
 end;
 
 procedure TFMXWorkScheduler.StopScheduler;

--- a/update_CEF4Delphi.json
+++ b/update_CEF4Delphi.json
@@ -2,9 +2,9 @@
   "UpdateLazPackages" : [
     {
       "ForceNotify" : true,
-      "InternalVersion" : 339,
+      "InternalVersion" : 340,
       "Name" : "cef4delphi_lazarus.lpk",
-      "Version" : "96.0.16.0"
+      "Version" : "96.0.17.0"
     }
   ],
   "UpdatePackageData" : {


### PR DESCRIPTION
Call SetProcessShutdownParameters with the same parameter values as Chromium does.
Fixed some backwards compatibility issues